### PR TITLE
Add Laravel package base

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto eol=lf
+
+*.md diff=markdown
+*.php diff=php
+
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /.idea
 /.vscode
+/vendor
+auth.json
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,33 @@
+{
+    "name": "maru0914/laravel-config-jp",
+    "description": "The Laravel config files will be translated into Japanese.",
+    "keywords": ["laravel", "config"],
+    "license": "MIT",
+    "support": {
+        "issues": "https://github.com/maru0914/laravel-config-jp/issues",
+        "source": "https://github.com/maru0914/laravel-config-jp"
+    },
+    "require": {
+        "php": "^8.2",
+        "illuminate/console": "^11.0",
+        "illuminate/support": "^11.0",
+        "symfony/console": "^7.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Maru0914\\LaravelConfigJp\\": "src/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Maru0914\\LaravelConfigJp\\LaravelConfigJpServiceProvider"
+            ]
+        }
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Maru0914\LaravelConfigJp\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'config-jp:publish')]
+class PublishCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'config-jp:publish
+                {name? : The name of the japanese configuration file to publish}
+                {--all : Publish all japanese configuration files}
+                {--force : Overwrite any existing japanese configuration files}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Publish japanese configuration files to your application';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        // Push configuration files.
+    }
+}

--- a/src/LaravelConfigJpServiceProvider.php
+++ b/src/LaravelConfigJpServiceProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Maru0914\LaravelConfigJp;
+
+use Illuminate\Support\ServiceProvider;
+
+class LaravelConfigJpServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                Console\PublishCommand::class,
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
I was inspired by your repository and wanted developers to use it. So I've added a small base to create a package for you to upload to [Packagist](https://packagist.org/). That way it can be used by other developers just by installing your package and getting the configs in Japanese using the `config-jp:publish` command.

Sorry.